### PR TITLE
Minor typo and formatting change

### DIFF
--- a/draft-birkholz-scitt-receipts.md
+++ b/draft-birkholz-scitt-receipts.md
@@ -70,7 +70,8 @@ We adopt the terminology of [architecture](pointer) for Claim, Envelope, Transpa
 
 From the Verifier's viewpoint, a Receipt is similar to a countersignature V2 on a single signed message: it is a universally-verifiable cryptographic proof of endorsement of the signed envelope by the countersigner.
 
-Compared with countersignatures on single COSE envelopes,
+Compared with countersignatures on single COSE envelopes:
+
 - Receipts countersign the envelope in context, providing authentication both of the envelope and of its logical position in the authenticated data structure.
 - Receipts are proof of commitment to the whole contents of the data structure, even if the Verifier knows only some of its contents.
 - Receipts can be issued in bulk, using a single public-key signature for issuing a large number of Receipts.
@@ -90,7 +91,7 @@ and securely communicated to all Verifiers.
 
 At minimum, these parameters include:
 
-- a Service identifier: An opaque identifier (e.g. UUID) that uniquely identifies the service and can be used to securely retrive all other Serivce parameters.
+- a Service identifier: An opaque identifier (e.g. UUID) that uniquely identifies the service and can be used to securely retrive all other Service parameters.
 
 - The Tree algorithm used for issuing receipts, and its additional global parameters, if any. This document creates a registry (see {{tree-alg-registry}}) and describes an initial set of tree algorithms.
 

--- a/draft-birkholz-scitt-receipts.md
+++ b/draft-birkholz-scitt-receipts.md
@@ -70,7 +70,7 @@ We adopt the terminology of [architecture](pointer) for Claim, Envelope, Transpa
 
 From the Verifier's viewpoint, a Receipt is similar to a countersignature V2 on a single signed message: it is a universally-verifiable cryptographic proof of endorsement of the signed envelope by the countersigner.
 
-Compared with countersignatures on single COSE envelopes:
+Compared with countersignatures on single COSE envelopes,
 
 - Receipts countersign the envelope in context, providing authentication both of the envelope and of its logical position in the authenticated data structure.
 - Receipts are proof of commitment to the whole contents of the data structure, even if the Verifier knows only some of its contents.


### PR DESCRIPTION
The first change is to address the fact that the current .md renders correctly as bullet list on Github but not in other contexts such as https://www.ietf.org/archive/id/draft-birkholz-scitt-receipts-00.html