### PR TITLE
Simplify receipt header parameter

### DIFF
--- a/draft-birkholz-scitt-receipts.md
+++ b/draft-birkholz-scitt-receipts.md
@@ -376,9 +376,9 @@ Name: COSE_Sign1 Countersign receipt
 
 Label: TBD
 
-Value Type: Receipt / \[+ Receipt\]
+Value Type: \[+ Receipt\]
 
-Description: A COSE_Sign1 Countersign Receipt to be embedded in the unprotected header of the countersigned COSE_Sign1 message.
+Description: One or more COSE_Sign1 Countersign Receipts to be embedded in the unprotected header of the countersigned COSE_Sign1 message.
 
 #### Issued At
 


### PR DESCRIPTION
Allowing both a receipt and an array of receipts as type is ambiguous here since the receipt is an array itself and not wrapped, so distinguishing the two cases wouldn't work. Having a single type also simplifies client code.